### PR TITLE
fixed two bit-logic bugs in authorization code (MellonCond)

### DIFF
--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -463,7 +463,7 @@ int am_check_permissions(request_rec *r, am_cache_entry_t *session)
             if (value == NULL) {
                  match = 0;          /* can not happen */
 
-            } else if (ce->flags & (AM_COND_FLAG_REG|AM_COND_FLAG_REF)) {
+            } else if ((ce->flags & AM_COND_FLAG_REG) && (ce->flags & AM_COND_FLAG_REF)) {
                  int nsub = ce->regex->re_nsub + 1;
                  ap_regmatch_t *regmatch;
 
@@ -477,7 +477,7 @@ int am_check_permissions(request_rec *r, am_cache_entry_t *session)
             } else if (ce->flags & AM_COND_FLAG_REG) {
                  match = !ap_regexec(ce->regex, value, 0, NULL, 0);
 
-            } else if (ce->flags & (AM_COND_FLAG_SUB|AM_COND_FLAG_NC)) {
+            } else if ((ce->flags & AM_COND_FLAG_SUB) && (ce->flags & AM_COND_FLAG_NC)) {
                  match = (ap_strcasestr(ce->str, value) != NULL);
 
             } else if (ce->flags & AM_COND_FLAG_SUB) {


### PR DESCRIPTION
Hi Volker,

there is a bug in the bit logic of the authorization code handling MellonCond. Example: you have two users, that can both authenticate with IdP:

* sunny
* sunny1977

Now you want to restrict access to /beach by doing something like this:

<Location /beach>
  AuthType Mellon
  MellonEnable auth
  MellonUser "uid"
  MellonCond uid sunny1977 [NC]
  ...
</Location>

So only "sunny1977" should be able to access /beach, but in fact also "sunny" can access it, because this "if" condition is true, even the SUB (substring match) option is not set in the configuration. Setting NC is sufficient to provoke this behavior.

    } else if (ce->flags & (AM_COND_FLAG_SUB|AM_COND_FLAG_NC)) {
        match = (ap_strcasestr(ce->str, value) != NULL);

So because of the automatically triggered substring match (which is not expected), also "sunny" has access.

Something similar happens for REG and REF. Please see patch.

Cheers
Volker
